### PR TITLE
Rename StravaAlt references to Travalt

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,4 +1,4 @@
-# StravaAlt Android
+# Travalt Android
 
 This module will contain the future Android application written in Kotlin.
 Currently it's a minimal placeholder project.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    namespace = "com.stravaalt.app"
+    namespace = "com.travalt.app"
     compileSdk = 33
 
     defaultConfig {
-        applicationId = "com.stravaalt.app"
+        applicationId = "com.travalt.app"
         minSdk = 26
         targetSdk = 33
         versionCode = 1

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<manifest package="com.stravaalt.app" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.travalt.app" xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="StravaAlt"
+        android:label="Travalt"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true"

--- a/android/app/src/main/java/com/travalt/app/MainActivity.kt
+++ b/android/app/src/main/java/com/travalt/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.stravaalt.app
+package com.travalt.app
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="StravaAlt Android"
+        android:text="Travalt Android"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -5,5 +5,5 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-rootProject.name = "strava-alt-android"
+rootProject.name = "travalt-android"
 include(":app")

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,5 +5,5 @@ RUN gradle installDist
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/build/install/strava-alt-backend/ /app/
-CMD ["./bin/strava-alt-backend"]
+COPY --from=build /app/build/install/travalt-backend/ /app/
+CMD ["./bin/travalt-backend"]

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 application {
-    mainClass.set("com.stravaalt.ApplicationKt")
+    mainClass.set("com.travalt.ApplicationKt")
 }
 
 kotlin {

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "strava-alt-backend"
+rootProject.name = "travalt-backend"

--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -1,4 +1,4 @@
-package com.stravaalt
+package com.travalt
 
 
 import io.ktor.server.application.Application
@@ -69,7 +69,7 @@ fun Application.module() {
 
     routing {
         get("/") {
-            call.respondText("StravaAlt backend running")
+            call.respondText("Travalt backend running")
         }
 
         route("/api/v1") {

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -3,6 +3,6 @@ ktor {
         port = 8080
     }
     application {
-        modules = [ com.stravaalt.ApplicationKt.module ]
+        modules = [ com.travalt.ApplicationKt.module ]
     }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-    <title>StravaAlt</title>
+    <title>Travalt</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "strava-alt-frontend",
+  "name": "travalt-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "strava-alt-frontend",
+      "name": "travalt-frontend",
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strava-alt-frontend",
+  "name": "travalt-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
   return (
     <>
       <header className="header">
-        <div className="logo">StravaAlt</div>
+        <div className="logo">Travalt</div>
         {user ? (
           <div className="user-block">
             <img src={user.avatar} alt="avatar" className="avatar" />
@@ -96,7 +96,7 @@ function App() {
       <main className="content">
         {view === 'home' && (
           <>
-            <h1>Welcome to StravaAlt</h1>
+            <h1>Welcome to Travalt</h1>
             {user && (
               <>
                 <h2>Последние активности</h2>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strava-alt-root",
+  "name": "travalt-root",
   "private": true,
   "scripts": {
     "dev": "concurrently \"npm run backend\" \"npm run frontend\"",


### PR DESCRIPTION
## Summary
- rename the project namespace and references from `stravaalt`/`strava-alt` to `travalt`
- update Android and backend package names
- update frontend and Dockerfile names

## Testing
- `gradle test` *(fails: Cannot find a Java installation on your machine)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f004a0408329a148d7bb423b4cfb