### PR TITLE
Make frontend redirect configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ The backend requires Strava API credentials. Set the following environment varia
 STRAVA_CLIENT_ID=<your_client_id>
 STRAVA_CLIENT_SECRET=<your_client_secret>
 STRAVA_REDIRECT_URI=http://localhost:8080/api/v1/callback
+FRONTEND_URL=http://localhost:5173
 ```
+
+`FRONTEND_URL` controls where the backend redirects users after authentication.
 
 The server will start on `http://localhost:8080`.
 All API endpoints are available under the `/api/v1` path.

--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -44,6 +44,7 @@ fun Application.module() {
     val clientId = System.getenv("STRAVA_CLIENT_ID") ?: error("STRAVA_CLIENT_ID not set")
     val clientSecret = System.getenv("STRAVA_CLIENT_SECRET") ?: error("STRAVA_CLIENT_SECRET not set")
     val redirectUri = System.getenv("STRAVA_REDIRECT_URI") ?: "http://localhost:8080/api/v1/callback"
+    val frontendUrl = System.getenv("FRONTEND_URL") ?: "http://localhost:5173"
 
     install(ContentNegotiation) {
         json(Json { prettyPrint = true; ignoreUnknownKeys = true })
@@ -99,12 +100,12 @@ fun Application.module() {
             }.body()
 
                 call.sessions.set(UserSession(token.access_token))
-                call.respondRedirect("http://localhost:5173")
+                call.respondRedirect(frontendUrl)
             }
 
             get("/logout") {
                 call.sessions.clear<UserSession>()
-                call.respondRedirect("http://localhost:5173")
+                call.respondRedirect(frontendUrl)
             }
 
             get("/me") {


### PR DESCRIPTION
## Summary
- configure redirect URL via `FRONTEND_URL`
- document the new environment variable

## Testing
- `gradle build`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863db0fd3448329abc4ff779a06c30a