### PR TITLE
Enable CallLogging with custom logger

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.1")
     implementation("io.ktor:ktor-server-sessions:2.3.1")
     implementation("io.ktor:ktor-server-cors:2.3.1")
+    implementation("io.ktor:ktor-server-call-logging-jvm:2.3.1")
     implementation("io.ktor:ktor-client-core:2.3.1")
     implementation("io.ktor:ktor-client-cio:2.3.1")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.1")

--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -13,6 +13,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.sessions.Sessions
 import io.ktor.server.sessions.cookie
 import io.ktor.server.sessions.sessions
@@ -35,6 +36,9 @@ import io.ktor.http.URLBuilder
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger("Application")
 
 fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
@@ -60,6 +64,10 @@ fun Application.module() {
         allowMethod(HttpMethod.Post)
         allowHeader(HttpHeaders.ContentType)
         anyHost()
+    }
+
+    install(CallLogging) {
+        logger = log
     }
 
     val httpClient = HttpClient(CIO) {
@@ -100,7 +108,7 @@ fun Application.module() {
                 }.body()
 
                 call.sessions.set(UserSession(token.access_token))
-                call.application.environment.log.info("Redirecting authenticated user to {}", frontendUrl)
+                log.info("Redirecting authenticated user to {}", frontendUrl)
                 call.respondRedirect(frontendUrl)
             }
 


### PR DESCRIPTION
## Summary
- add CallLogging dependency
- configure CallLogging plugin with logger created via `LoggerFactory`
- log callback redirects using the new logger

## Testing
- `gradle -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_68640260979c832999b839aa54994bf2