### PR TITLE
Move backend config to application.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ STRAVA_REDIRECT_URI=http://localhost:8080/api/v1/callback
 FRONTEND_URL=http://localhost:5173
 ```
 
-`FRONTEND_URL` controls where the backend redirects users after authentication.
+`FRONTEND_URL` controls where the backend redirects users after authentication. These variables are referenced in `application.conf`.
 
 The server will start on `http://localhost:8080`.
 All API endpoints are available under the `/api/v1` path.

--- a/backend/src/main/kotlin/com/travalt/AppConfig.kt
+++ b/backend/src/main/kotlin/com/travalt/AppConfig.kt
@@ -1,0 +1,51 @@
+package com.travalt
+
+import com.typesafe.config.ConfigFactory
+
+/**
+ * Application configuration loaded from [application.conf].
+ */
+data class AppConfig(
+    val stravaClientId: String,
+    val stravaClientSecret: String,
+    val stravaRedirectUri: String,
+    val frontendUrl: String
+) {
+    companion object {
+        fun load(): AppConfig {
+            val config = ConfigFactory.load().getConfig("app")
+
+            val clientId = if (config.hasPath("strava.clientId"))
+                config.getString("strava.clientId")
+            else error("strava.clientId not set")
+
+            val clientSecret = if (config.hasPath("strava.clientSecret"))
+                config.getString("strava.clientSecret")
+            else error("strava.clientSecret not set")
+
+            val redirectUri = if (config.hasPath("strava.redirectUri"))
+                config.getString("strava.redirectUri")
+            else "http://localhost:8080/api/v1/callback"
+
+            val frontendUrl = if (config.hasPath("frontend.url"))
+                config.getString("frontend.url")
+            else "http://localhost:5173"
+
+            return AppConfig(
+                stravaClientId = clientId,
+                stravaClientSecret = clientSecret,
+                stravaRedirectUri = redirectUri,
+                frontendUrl = frontendUrl
+            )
+        }
+    }
+
+    fun logSanitized(log: org.slf4j.Logger) {
+        log.info(
+            "AppConfig: stravaClientId={}, stravaRedirectUri={}, frontendUrl={}",
+            stravaClientId,
+            stravaRedirectUri,
+            frontendUrl
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -38,6 +38,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 
+import com.travalt.AppConfig
+
 private val log = LoggerFactory.getLogger("Application")
 
 fun main() {
@@ -45,10 +47,11 @@ fun main() {
 }
 
 fun Application.module() {
-    val clientId = System.getenv("STRAVA_CLIENT_ID") ?: error("STRAVA_CLIENT_ID not set")
-    val clientSecret = System.getenv("STRAVA_CLIENT_SECRET") ?: error("STRAVA_CLIENT_SECRET not set")
-    val redirectUri = System.getenv("STRAVA_REDIRECT_URI") ?: "http://localhost:8080/api/v1/callback"
-    val frontendUrl = System.getenv("FRONTEND_URL") ?: "http://localhost:5173"
+    val config = AppConfig.load().also { it.logSanitized(log) }
+    val clientId = config.stravaClientId
+    val clientSecret = config.stravaClientSecret
+    val redirectUri = config.stravaRedirectUri
+    val frontendUrl = config.frontendUrl
 
     install(ContentNegotiation) {
         json(Json { prettyPrint = true; ignoreUnknownKeys = true })

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -6,3 +6,10 @@ ktor {
         modules = [ com.travalt.ApplicationKt.module ]
     }
 }
+
+app {
+    strava.clientId = ${?STRAVA_CLIENT_ID}
+    strava.clientSecret = ${?STRAVA_CLIENT_SECRET}
+    strava.redirectUri = ${?STRAVA_REDIRECT_URI}
+    frontend.url = ${?FRONTEND_URL}
+}


### PR DESCRIPTION
## Summary
- remove the application.properties file
- define environment-based settings inside application.conf
- load configuration from application.conf via the new AppConfig wrapper
- update README to show environment variables again

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_686408658cf4832999f0b171b4e7f3bd