### PR TITLE
Switch to access/refresh token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ STRAVA_CLIENT_ID=<your_client_id>
 STRAVA_CLIENT_SECRET=<your_client_secret>
 STRAVA_REDIRECT_URI=http://localhost:8080/api/v1/callback
 FRONTEND_URL=http://localhost:5173
+COOKIE_DOMAIN=localhost
 ```
 
-`FRONTEND_URL` controls where the backend redirects users after authentication. These variables are referenced in `application.conf`.
+`FRONTEND_URL` controls where the backend redirects users after authentication.
+`COOKIE_DOMAIN` should be set to the parent domain shared by the frontend and backend so that refresh tokens work across subdomains.
+These variables are referenced in `application.conf`.
 
 The server will start on `http://localhost:8080`.
 All API endpoints are available under the `/api/v1` path.
@@ -61,7 +64,7 @@ npm run dev
 
 The app will be available at `http://localhost:5173` by default.
 
-Open the frontend in your browser and click "Login with Strava" to authorize and see your name in the top right corner.
+Open the frontend in your browser and click "Login with Strava". After authenticating with Strava you will be redirected back with an `access_token` query parameter. The frontend stores this value locally and uses a refresh token cookie set by the backend to obtain new access tokens when needed.
 
 ## Android project
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation("io.ktor:ktor-server-core:2.3.1")
     implementation("io.ktor:ktor-server-content-negotiation:2.3.1")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.1")
-    implementation("io.ktor:ktor-server-sessions:2.3.1")
     implementation("io.ktor:ktor-server-cors:2.3.1")
     implementation("io.ktor:ktor-server-call-logging-jvm:2.3.1")
     implementation("io.ktor:ktor-client-core:2.3.1")

--- a/backend/src/main/kotlin/com/travalt/AppConfig.kt
+++ b/backend/src/main/kotlin/com/travalt/AppConfig.kt
@@ -9,7 +9,8 @@ data class AppConfig(
     val stravaClientId: String,
     val stravaClientSecret: String,
     val stravaRedirectUri: String,
-    val frontendUrl: String
+    val frontendUrl: String,
+    val cookieDomain: String?
 ) {
     companion object {
         fun load(): AppConfig {
@@ -31,21 +32,27 @@ data class AppConfig(
                 config.getString("frontend.url")
             else "http://localhost:5173"
 
+            val cookieDomain = if (config.hasPath("cookie.domain"))
+                config.getString("cookie.domain")
+            else null
+
             return AppConfig(
                 stravaClientId = clientId,
                 stravaClientSecret = clientSecret,
                 stravaRedirectUri = redirectUri,
-                frontendUrl = frontendUrl
+                frontendUrl = frontendUrl,
+                cookieDomain = cookieDomain
             )
         }
     }
 
     fun logSanitized(log: org.slf4j.Logger) {
         log.info(
-            "AppConfig: stravaClientId={}, stravaRedirectUri={}, frontendUrl={}",
+            "AppConfig: stravaClientId={}, stravaRedirectUri={}, frontendUrl={}, cookieDomain={}",
             stravaClientId,
             stravaRedirectUri,
-            frontendUrl
+            frontendUrl,
+            cookieDomain ?: "<none>"
         )
     }
 }

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -12,4 +12,5 @@ app {
     strava.clientSecret = ${?STRAVA_CLIENT_SECRET}
     strava.redirectUri = ${?STRAVA_REDIRECT_URI}
     frontend.url = ${?FRONTEND_URL}
+    cookie.domain = ${?COOKIE_DOMAIN}
 }


### PR DESCRIPTION
## Summary
- store refresh token cookie across subdomains
- add `/refresh` endpoint and expect bearer tokens for API calls
- update React frontend to handle token-based auth
- document new `COOKIE_DOMAIN` variable and login flow

## Testing
- `gradle build -x test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68641a98763c832993356dc5ce6e60ef