### PR TITLE
Fix missing Strava activity scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ FRONTEND_URL=http://localhost:5173
 COOKIE_DOMAIN=localhost
 ```
 
+The login flow requests the `activity:read` scope so the backend can fetch
+user activities from Strava. Ensure your application is allowed to access this
+scope in the Strava developer settings.
+
 `FRONTEND_URL` controls where the backend redirects users after authentication.
 `COOKIE_DOMAIN` should be set to the parent domain shared by the frontend and backend so that refresh tokens work across subdomains.
 These variables are referenced in `application.conf`.

--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -85,7 +85,7 @@ fun Application.module() {
                     parameters.append("client_id", clientId)
                     parameters.append("redirect_uri", redirectUri)
                     parameters.append("response_type", "code")
-                    parameters.append("scope", "read")
+                    parameters.append("scope", "read,activity:read")
                     parameters.append("approval_prompt", "auto")
                 }.buildString()
                 call.respondRedirect(url)


### PR DESCRIPTION
## Summary
- request `activity:read` during Strava login so `/activities` works
- document the required Strava scope in README

## Testing
- `gradle test` *(fails: cannot find JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_68643b3d36388329acfb68825f12892f