### PR TITLE
Move 'All' activities button into header

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -67,6 +67,13 @@ h1 {
   color: #8a56ff;
 }
 
+.activity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem 0;
+}
+
 .activity-list {
   list-style: none;
   padding: 0;
@@ -80,14 +87,18 @@ h1 {
   border-bottom: 1px solid #eee;
 }
 
+
 .all-button, .back-button {
-  margin-top: 1rem;
   padding: 0.5rem 1rem;
   background: #8a56ff;
   color: white;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.back-button {
+  margin-top: 1rem;
 }
 
 .all-button:hover, .back-button:hover {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -149,15 +149,8 @@ function App() {
             <h1>Welcome to Travalt</h1>
             {user && (
               <>
+              <div className="activity-header">
                 <h2>Последние активности</h2>
-                <ul className="activity-list">
-                  {recent.map(a => (
-                    <li key={a.id} className="activity-item">
-                      <span>{emojiMap[a.type] || '❓'} {a.name}</span>
-                      <span>{new Date(a.start_date).toLocaleDateString()}</span>
-                    </li>
-                  ))}
-                </ul>
                 <button
                   onClick={() => {
                     setActivities([])
@@ -169,6 +162,15 @@ function App() {
                 >
                   Все
                 </button>
+              </div>
+              <ul className="activity-list">
+                  {recent.map(a => (
+                    <li key={a.id} className="activity-item">
+                      <span>{emojiMap[a.type] || '❓'} {a.name}</span>
+                      <span>{new Date(a.start_date).toLocaleDateString()}</span>
+                    </li>
+                  ))}
+                </ul>
               </>
             )}
           </>


### PR DESCRIPTION
## Summary
- move button for viewing all activities into a new `activity-header` container
- style header to align button with the "Последние активности" text
- adjust button margins so only the back button has top margin

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68643f4bc168832992b1764bc6280c1f