### PR TITLE
Show training time in activity list

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
               {activities.map(a => (
                 <li key={a.id} className="activity-item">
                   <span>{emojiMap[a.type] || '❓'} {a.name}</span>
-                  <span>{new Date(a.start_date).toLocaleDateString()}</span>
+                  <span>{new Date(a.start_date).toLocaleString()}</span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- display both date and time for activity start

## Testing
- `npm --prefix frontend run build`
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68643ffc647883298cae58d110aaf7df