### PR TITLE
Fix activity page display issues and camelCase output

### DIFF
--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -203,9 +203,23 @@ fun Application.module() {
                 }.body()
 
                 val start = offset % limit
-                val result = if (start > 0) activities.drop(start) else activities
+                val slice = if (start > 0) activities.drop(start) else activities
 
-                call.respond(result)
+                val response = slice.map {
+                    Activity(
+                        id = it.id,
+                        name = it.name,
+                        startDate = it.startDate,
+                        type = it.type,
+                        averageHeartrate = it.averageHeartrate,
+                        averageSpeed = it.averageSpeed,
+                        movingTime = it.movingTime,
+                        distance = it.distance,
+                        averageCadence = it.averageCadence
+                    )
+                }
+
+                call.respond(response)
             }
         }
     }
@@ -240,5 +254,18 @@ data class ActivitySummary(
     val movingTime: Int? = null,
     val distance: Double? = null,
     @SerialName("average_cadence")
+    val averageCadence: Double? = null
+)
+
+@Serializable
+data class Activity(
+    val id: Long,
+    val name: String,
+    val startDate: String,
+    val type: String,
+    val averageHeartrate: Double? = null,
+    val averageSpeed: Double? = null,
+    val movingTime: Int? = null,
+    val distance: Double? = null,
     val averageCadence: Double? = null
 )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -183,7 +183,7 @@ function App() {
                   {recent.map(a => (
                     <li key={a.id} className="activity-item">
                       <span>{emojiMap[a.type] || '❓'} {a.name}</span>
-                      <span>{new Date(a.start_date).toLocaleString()}</span>
+                      <span>{new Date(a.startDate).toLocaleString()}</span>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly BACKEND_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- fix missing type declaration for `import.meta.env`
- send activities with camelCase fields in API
- show activity date properly on home page

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686455bf99448329ad66b417f48e7806