### PR TITLE
Center activities header

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -80,6 +80,18 @@ h1 {
   border-bottom: 1px solid #eee;
 }
 
+.activities-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.activities-header h2 {
+  margin: 0 auto;
+}
+
 
 .activity-header {
   display: flex;
@@ -106,6 +118,13 @@ h1 {
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.activities-header .all-button {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .back-button {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -165,7 +165,7 @@ function App() {
             {!user && <h1>Welcome to Travalt</h1>}
             {user && (
               <>
-              <div className="activity-header">
+              <div className="activities-header">
                 <h2>Последние активности</h2>
                 <button
                   onClick={() => {


### PR DESCRIPTION
## Summary
- show home activities heading centered with a new CSS class
- keep the "All" button on the right edge

## Testing
- `npm --prefix frontend run build`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68645b154ab88329855d517417b12acf